### PR TITLE
Fix warnings

### DIFF
--- a/src/cldfgeojson/commands/geojson.py
+++ b/src/cldfgeojson/commands/geojson.py
@@ -122,8 +122,8 @@ def run(args):
                     ))
                 else:  # pragma: no cover
                     args.log.warning('No Glottolog coordinate for language ID {}'.format(lg.id))
-    for lang in lids:
-        if lang not in checked:
-            args.log.warning(f'{lang} not found in polygon dataset.')
+
+    for lang in set(lids) - set(checked):
+        args.log.warning(f'{lang} not found in polygon dataset.')
 
     print(json.dumps(feature_collection(features), indent=2))

--- a/src/cldfgeojson/commands/geojson.py
+++ b/src/cldfgeojson/commands/geojson.py
@@ -84,6 +84,9 @@ def run(args):
                 feature = dict(type='Feature', geometry=shp.__geo_interface__, properties=props)
             elif lg.cldf.speakerArea:  # pragma: no cover
                 feature = lg.speaker_area_as_geojson_feature
+            else:  # pragma: no cover
+                args.log.warning('No speaker area for language ID {}'.format(lg.id))
+                continue
             for k, v in lg.data.items():
                 if k not in {'ID', 'Name', 'Latitude', 'Longitude', 'Glottocode'}:
                     feature['properties'].setdefault(k, str(v))
@@ -121,6 +124,6 @@ def run(args):
                     args.log.warning('No Glottolog coordinate for language ID {}'.format(lg.id))
     for lang in lids:
         if lang not in checked:
-            args.log.warning(f'No speaker area for language ID {lang}')
+            args.log.warning(f'{lang} not found in polygon dataset.')
 
     print(json.dumps(feature_collection(features), indent=2))

--- a/src/cldfgeojson/commands/geojson.py
+++ b/src/cldfgeojson/commands/geojson.py
@@ -75,16 +75,15 @@ def run(args):
                     geojsons2[lid2gc[lid][1]] = v
 
     features = []
+    checked = []
     for lg in ds.objects('LanguageTable'):
         if (ds2 is None and lg.id in lids) or (ds2 and lg.cldf.glottocode in lids):
+            checked.append(lg.cldf.glottocode)
             if lg.cldf.speakerArea in geojsons:
                 shp, props = geojsons[lg.cldf.speakerArea][lg.cldf.id]
                 feature = dict(type='Feature', geometry=shp.__geo_interface__, properties=props)
             elif lg.cldf.speakerArea:  # pragma: no cover
                 feature = lg.speaker_area_as_geojson_feature
-            else:  # pragma: no cover
-                args.log.warning('No speaker area for language ID {}'.format(lg.id))
-                continue
             for k, v in lg.data.items():
                 if k not in {'ID', 'Name', 'Latitude', 'Longitude', 'Glottocode'}:
                     feature['properties'].setdefault(k, str(v))
@@ -108,7 +107,7 @@ def run(args):
                     })
                     features.append(feature)
 
-            if args.glottolog:
+            if args.glottolog and not args.no_glottolog:
                 if lg.cldf.glottocode in gl:
                     glang = gl[lg.cldf.glottocode]
                     features.append(dict(
@@ -120,4 +119,8 @@ def run(args):
                     ))
                 else:  # pragma: no cover
                     args.log.warning('No Glottolog coordinate for language ID {}'.format(lg.id))
+    for lang in lids:
+        if lang not in checked:
+            args.log.warning(f'No speaker area for language ID {lang}')
+
     print(json.dumps(feature_collection(features), indent=2))


### PR DESCRIPTION
@xrotwang I stumbled across the warning "No Glottolog coordinates for x" for languages which definitely have it, while missing a warning when a glottocode is not featured in a dataset.

To reproduce:

```shell
(polygons) frederic@Mac polygons % csvcut -c Glottocode ../amazonianvoices/cldf/languages.csv | \
csvformat -E | \
cldfbench geojson.geojson --no-glottolog asher2007world/cldf/traditional - \
> av.geojson
```

I receive warnings about missing Glottolog coordinates:

```shell
WARNING No Glottolog coordinate for language ID agua1253
WARNING No Glottolog coordinate for language ID amah1246
WARNING No Glottolog coordinate for language ID asha1243
WARNING No Glottolog coordinate for language ID bora1263
WARNING No Glottolog coordinate for language ID cash1254
WARNING No Glottolog coordinate for language ID chay1248
WARNING No Glottolog coordinate for language ID culi1244
[...]
```

But not about the languages which are not in Asher 2007 (e.g. isco1239, past1249).

The changes to the `geojson` command fix this by adding a second condition to the point coordinate prompt (not args.no_glottolog), and by adding a check which glottocodes that are part of the input have not been utilized in the for-loop through the json-repository.